### PR TITLE
Changed upper bound on `pipes` to `< 4.2`

### DIFF
--- a/pipes-zlib.cabal
+++ b/pipes-zlib.cabal
@@ -25,7 +25,7 @@ library
     exposed-modules: Pipes.Zlib
     build-depends:   base             (>= 4.5 && < 5.0)
                    , transformers     (>= 0.2 && < 0.4)
-                   , pipes            (>= 4.0 && < 4.1)
+                   , pipes            (>= 4.0 && < 4.2)
                    , bytestring       (>= 0.9.2.1)
                    , zlib             (>= 0.5 && < 0.7)
                    , zlib-bindings    (>= 0.1 && < 0.2)


### PR DESCRIPTION
`pipes-4.1.0` got a version bump because it removes the dependency on the `void` package, which is only a breaking change if you used the `Void` type explicitly instead of the type synonyms.  For `pipes-zlib` this is a backwards compatible change so this pull request just updates the upper bound.
