### PR TITLE
Fix truncated deflate output

### DIFF
--- a/src/Pipes/Zlib.hs
+++ b/src/Pipes/Zlib.hs
@@ -64,10 +64,7 @@ compress clevel wbits p0 = do
     r <- for p0 $ \bs -> do
        popper <- liftIO (Z.feedDeflate def bs)
        fromPopper popper
-    mbs <- liftIO $ Z.finishDeflate def
-    case mbs of
-       Just bs -> yield bs
-       Nothing -> return ()
+    fromPopper $ Z.finishDeflate def
     return r
 {-# INLINABLE compress #-}
 


### PR DESCRIPTION
The `Popper` returned by `finishDeflate` may need to be called multiple times to produce all of the remaining compressed output. This is mostly noticeable when the input is incompressible and near a multiple of the chunk size. [Here's a test program](https://www.fpcomplete.com/user/nanotech/pipes-zlib-truncation) that shows the problem.

[`conduit-extra` solves this by calling `finishDeflate` repeatedly](https://github.com/snoyberg/conduit/blob/df3045ea0da1a78d3c15bbad8233610dc384f693/conduit-extra/Data/Conduit/Zlib.hs#L157), but I think that's only safe because [`finishDeflate` always returns an identical `Popper`](https://github.com/snoyberg/zlib-bindings/blob/5c94ad4ca6bd882bc666b32df5c863085e5318be/Codec/Zlib.hs#L265) on each call.
