### PR TITLE
Port to streaming-commons

### DIFF
--- a/pipes-zlib.cabal
+++ b/pipes-zlib.cabal
@@ -28,6 +28,5 @@ library
                    , transformers     (>= 0.2 && < 0.5)
                    , pipes            (>= 4.0 && < 4.2)
                    , bytestring       (>= 0.9.2.1)
-                   , zlib             (>= 0.5 && < 0.7)
-                   , zlib-bindings    (>= 0.1 && < 0.2)
+                   , streaming-commons(>= 0.1.15 && < 0.2)
     ghc-options: -Wall -O2

--- a/pipes-zlib.cabal
+++ b/pipes-zlib.cabal
@@ -25,7 +25,7 @@ library
     exposed-modules: Pipes.Zlib
                      Pipes.GZip
     build-depends:   base             (>= 4.5 && < 5.0)
-                   , transformers     (>= 0.2 && < 0.5)
+                   , transformers     (>= 0.2 && < 0.6)
                    , pipes            (>= 4.0 && < 4.2)
                    , bytestring       (>= 0.9.2.1)
                    , streaming-commons(>= 0.1.15 && < 0.2)


### PR DESCRIPTION
bindings-zlib is now deprecated. Moreover, the `streaming-commons`
interface provides access to leftovers.