### PR TITLE
Handle archives that are made up of several concatenated archives

### DIFF
--- a/src/Pipes/GZip.hs
+++ b/src/Pipes/GZip.hs
@@ -34,8 +34,8 @@ import qualified Pipes.Zlib
 -- @
 decompress
   :: MonadIO m
-  => Proxy x' x () B.ByteString m r -- ^ Compressed stream
-  -> Proxy x' x () B.ByteString m r -- ^ Decompressed stream
+  => Producer B.ByteString m r -- ^ Compressed stream
+  -> Producer B.ByteString m r -- ^ Decompressed stream
 decompress = Pipes.Zlib.decompress gzWindowBits
 {-# INLINABLE decompress #-}
 

--- a/src/Pipes/GZip.hs
+++ b/src/Pipes/GZip.hs
@@ -35,7 +35,7 @@ import qualified Pipes.Zlib
 decompress
   :: MonadIO m
   => Producer B.ByteString m r -- ^ Compressed stream
-  -> Producer B.ByteString m r -- ^ Decompressed stream
+  -> Producer' B.ByteString m r -- ^ Decompressed stream
 decompress = Pipes.Zlib.decompress gzWindowBits
 {-# INLINABLE decompress #-}
 
@@ -44,7 +44,7 @@ decompress = Pipes.Zlib.decompress gzWindowBits
 decompress'
   :: MonadIO m
   => Producer B.ByteString m r -- ^ Compressed stream
-  -> Producer B.ByteString m (Either (Producer B.ByteString m r) r)
+  -> Producer' B.ByteString m (Either (Producer B.ByteString m r) r)
      -- ^ Decompressed stream, returning either a 'Producer' of the leftover input
      -- or the return value from the input 'Producer'.
 decompress' = Pipes.Zlib.decompress' gzWindowBits
@@ -62,8 +62,8 @@ decompress' = Pipes.Zlib.decompress' gzWindowBits
 compress
   :: MonadIO m
   => Pipes.Zlib.CompressionLevel
-  -> Proxy x' x () B.ByteString m r -- ^ Decompressed stream
-  -> Proxy x' x () B.ByteString m r -- ^ Compressed stream
+  -> Producer B.ByteString m r -- ^ Decompressed stream
+  -> Producer' B.ByteString m r -- ^ Compressed stream
 compress clevel = Pipes.Zlib.compress clevel gzWindowBits
 {-# INLINABLE compress #-}
 

--- a/src/Pipes/Zlib.hs
+++ b/src/Pipes/Zlib.hs
@@ -48,16 +48,11 @@ import           Pipes
 decompress
   :: MonadIO m
   => Z.WindowBits
-  -> Proxy x' x () B.ByteString m r -- ^ Compressed stream
-  -> Proxy x' x () B.ByteString m r -- ^ Decompressed stream
-decompress wbits p0 = do
-    inf <- liftIO $ Z.initInflate wbits
-    r <- for p0 $ \bs -> do
-       popper <- liftIO (Z.feedInflate inf bs)
-       fromPopper popper
-    bs <- liftIO $ Z.finishInflate inf
-    unless (B.null bs) (yield bs)
-    return r
+  -> Producer B.ByteString m r -- ^ Compressed stream
+  -> Producer B.ByteString m r -- ^ Decompressed stream
+decompress wbits p0 = go p0
+  where
+    go p = decompress' wbits p >>= either go return
 {-# INLINABLE decompress #-}
 
 -- | Decompress bytes flowing from a 'Producer', returning any leftover input
@@ -68,18 +63,20 @@ decompress'
   -> Producer B.ByteString m r -- ^ Compressed stream
   -> Producer B.ByteString m (Either (Producer B.ByteString m r) r)
      -- ^ Decompressed stream, ending with either leftovers or a result
-decompress' wbits p0 = go p0 =<< liftIO (Z.initInflate wbits)
+decompress' wbits p0 = do
+          inf <- liftIO $ Z.initInflate wbits
+          res <- go p0 inf
+          bs <- liftIO $ Z.finishInflate inf
+          unless (B.null bs) (yield bs)
+          return res
   where
-    flush inf = do
-      bs <- liftIO $ Z.flushInflate inf
-      unless (B.null bs) (yield bs)
     go p inf = do
       res <- lift (next p)
       case res of
          Left r -> return $ Right r
          Right (bs, p') -> do
-            fromPopper =<< liftIO (Z.feedInflate inf bs)
-            flush inf
+            popper <- liftIO $ Z.feedInflate inf bs
+            fromPopper popper
             leftover <- liftIO $ Z.getUnusedInflate inf
             if B.null leftover
                then go p' inf


### PR DESCRIPTION
As discussed in #16 

Some observations:

* I've slightly tidied the implementation of `decompress'`.  There's no need to keep flushing the `Inflate`: it's sufficient to do it once, after the `Inflate` reports that it has not used all of the bytes we fed into it

* This fix does cause `decompress` to have a less general type signature.  IMO this is unlikely to be a problem, but perhaps I'm wrong

* In the corresponding conduit fix, they left their original `decompress` alone, and introduced `multiple` for this case.
  * IMO (again!) this is a mistake: I can't see when I would prefer to run a less good `decompress` that fails on some archives.  It seems to me that this change is just a plain old improvement.
  * So I've taken the view that I can simply fix `decompress` to be better

But reasonable people might disagree on these last two points so maybe it would make sense eg to rename the old `decompress` as `decompress1`, or just to leave the old `decompress` alone and give the 'fixed' version another name altogether.  What do you think?